### PR TITLE
Added missing content-type for PUT, POST and DELETE requests.

### DIFF
--- a/src/RabbitMq/ManagementApi/Client.php
+++ b/src/RabbitMq/ManagementApi/Client.php
@@ -191,6 +191,11 @@ class Client
         }
         
         $request = $this->client->createRequest($method, $endpoint, $headers, $body)->setAuth($this->username, $this->password);
+        
+        if (in_array($method, array('PUT', 'POST', 'DELETE'))) {
+            $request->setHeader('content-type', 'application/json');
+        }
+        
         $response = $request->send();
 
         return json_decode($response->getBody(), true);


### PR DESCRIPTION
PUT, POST and DELETE requests must send a content-type "application/json". See http://hg.rabbitmq.com/rabbitmq-management/raw-file/3646dee55e02/priv/www-api/help.html

Otherwise the following exception is thrown:

```
PHP Fatal error:  Uncaught exception 'Guzzle\Http\Exception\ClientErrorResponseException' with message 'Client error response
[status code] 415
[reason phrase] Unsupported Media Type
[url] http://localhost:15672/api/users/phil' in /tmp/wkr_repo/vendor/guzzle/guzzle/src/Guzzle/Http/Exception/BadResponseException.php:44
Stack trace:
#0 /tmp/wkr_repo/vendor/guzzle/guzzle/src/Guzzle/Http/Message/Request.php(145): Guzzle\Http\Exception\BadResponseException::factory(Object(Guzzle\Http\Message\EntityEnclosingRequest), Object(Guzzle\Http\Message\Response))
#1 [internal function]: Guzzle\Http\Message\Request::onRequestError(Object(Guzzle\Common\Event))
#2 /tmp/wkr_repo/vendor/symfony/event-dispatcher/Symfony/Component/EventDispatcher/EventDispatcher.php(164): call_user_func(Array, Object(Guzzle\Common\Event))
#3 /tmp/wkr_repo/vendor/symfony/event-dispatcher/Symfony/Component/EventDispatcher/EventDispatcher.php(53): Symfony\Component\EventDispatcher\EventDispatcher->doDispatch(Array, 'request.error', Object(Guzzle\Common\Event))
#4 /tmp in /tmp/wkr_repo/vendor/guzzle/guzzle/src/Guzzle/Http/Exception/BadResponseException.php on line 44
```
