### PR TITLE
On create binding, have default routing key of empty string.

### DIFF
--- a/src/RabbitMq/ManagementApi/Api/Binding.php
+++ b/src/RabbitMq/ManagementApi/Api/Binding.php
@@ -63,6 +63,8 @@ class Binding extends AbstractApi
 
         if ($routingKey) {
             $parameters['routing_key'] = $routingKey;
+        } else {
+            $parameters['routing_key'] = '';
         }
         if ($arguments) {
             $parameters['arguments'] = $arguments;


### PR DESCRIPTION
RabbitMQ api 500's if no routing_key is posted to it and unable to pass empty string correctly
