### PR TITLE
Add request to /consumer(s)

### DIFF
--- a/src/Api/Consumer.php
+++ b/src/Api/Consumer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace RabbitMq\ManagementApi\Api;
+
+/**
+ * Channel
+ *
+ * @author Richard Fullmer <richard.fullmer@opensoftdev.com>
+ */
+class Consumer extends AbstractApi
+{
+    /**
+     * A list of all open consumers.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->client->send('/api/consumers');
+    }
+
+    /**
+     * Details about an individual consumer.
+     *
+     * @param string $vhost
+     * @return array
+     */
+    public function get($vhost)
+    {
+        return $this->client->send(sprintf('/api/consumers/%s', urlencode($vhost)));
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -114,6 +114,14 @@ class Client
     }
 
     /**
+     * @return Api\Consumer
+     */
+    public function consumers()
+    {
+        return new Api\Consumer($this);
+    }
+
+    /**
      * @return Api\Exchange
      */
     public function exchanges()


### PR DESCRIPTION
For check connection on host (worker)

```
bash-5.0$ hostname 
5ae2119427cb
```

```
if (gethostname() === $item[consumer_tag']) {
// this worker connection successful
} else {
// exit(1);
}
```

```
// /api/consumers

Array
(
    [0] => Array
        (
            [arguments] => Array
                (
                )

            [ack_required] => 1
            [active] => 1
            [activity_status] => up
            [channel_details] => Array
                (
                    [connection_name] => 172.20.0.5:47590 -> 172.20.0.4:5672
                    [name] => 172.20.0.5:47590 -> 172.20.0.4:5672 (1)
                    [node] => rabbit@1bcdfce64b05
                    [number] => 1
                    [peer_host] => 172.20.0.5
                    [peer_port] => 47590
                    [user] => ts-ts
                )

            [consumer_tag] => PHPPROCESS_5ae2119427cb_16
            [exclusive] => 
            [prefetch_count] => 0
            [queue] => Array
                (
                    [name] => consumer-name
                    [vhost] => /
                )

        )

)
```