### PR TITLE
Update dependencies to allow PHP 8; drop PHP <7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PHP RabbitMQ Management Api
 ===========================
 
-A simple object oriented wrapper for the [RabbitMQ Management HTTP Api](http://hg.rabbitmq.com/rabbitmq-management/raw-file/rabbitmq_v3_0_3/priv/www/api/index.html) in PHP 5.3
+A simple object oriented wrapper for the [RabbitMQ Management HTTP Api](http://hg.rabbitmq.com/rabbitmq-management/raw-file/rabbitmq_v3_0_3/priv/www/api/index.html) in PHP 7.1+
 
 Uses [PHP-HTTP](http://docs.php-http.org/en/latest/index.html) for requests.
 
@@ -16,10 +16,10 @@ $ composer require richardfullmer/rabbitmq-management-api
 
 Additionally, you require a [httplug compatible client](http://docs.php-http.org/en/latest/clients.html).
 
-For example, use the guzzle6 adapter:
+For example, use the Guzzle 7 adapter:
 
 ```bash
-$ composer require php-http/guzzle6-adapter
+$ composer require php-http/guzzle7-adapter
 ```
 
 Basic Usage

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.1",
         "psr/http-message": "^1.0",
         "php-http/client-implementation": "^1.0",
-        "php-http/client-common": "^1.0",
-        "php-http/httplug": "^1.0",
+        "php-http/client-common": "^2.2.1",
+        "php-http/httplug": "^2.0",
         "php-http/message-factory": "^1.0",
         "php-http/discovery": "^1.0"
     },


### PR DESCRIPTION
- Update php-http/client-common to 2.2.1 and httplug to 2 to allow PHP 8;
- Drop PHP <7.1 following the updated dependencies;
- Recommend Guzzle 7 as it's the minimum now.

This library has no tests but the `Client` API appears to be the same, so should work I guess.